### PR TITLE
Cache classIndex at InstanceImpl initialization

### DIFF
--- a/moa/src/main/java/com/yahoo/labs/samoa/instances/InstanceImpl.java
+++ b/moa/src/main/java/com/yahoo/labs/samoa/instances/InstanceImpl.java
@@ -53,13 +53,7 @@ public class InstanceImpl implements MultiLabelInstance {
         this.weight = inst.weight;
         this.instanceData = inst.instanceData.copy();
         this.instanceHeader = inst.instanceHeader;
-        this.classIndex = this.instanceHeader.classIndex();
-        if(this.classIndex == Integer.MAX_VALUE) {
-          if(this.instanceHeader.instanceInformation.range!=null)
-            this.classIndex=this.instanceHeader.instanceInformation.range.getStart();
-          else
-            this.classIndex=0;
-        }
+        this.classIndex = -1;
     }
 
     //Dense
@@ -298,6 +292,15 @@ public class InstanceImpl implements MultiLabelInstance {
      */
     @Override
     public int classIndex() {
+        if (this.classIndex == -1) {
+            this.classIndex = this.instanceHeader.classIndex();
+            if(this.classIndex == Integer.MAX_VALUE) {
+              if(this.instanceHeader.instanceInformation.range!=null)
+                this.classIndex=this.instanceHeader.instanceInformation.range.getStart();
+              else
+                this.classIndex=0;
+            }
+        }
         return this.classIndex;
     }
 

--- a/moa/src/main/java/com/yahoo/labs/samoa/instances/InstanceImpl.java
+++ b/moa/src/main/java/com/yahoo/labs/samoa/instances/InstanceImpl.java
@@ -40,6 +40,11 @@ public class InstanceImpl implements MultiLabelInstance {
     protected InstancesHeader instanceHeader;
 
     /**
+     * The instance class index.
+     */
+    protected int classIndex;
+
+    /**
      * Instantiates a new instance.
      *
      * @param inst the inst
@@ -48,6 +53,13 @@ public class InstanceImpl implements MultiLabelInstance {
         this.weight = inst.weight;
         this.instanceData = inst.instanceData.copy();
         this.instanceHeader = inst.instanceHeader;
+        this.classIndex = this.instanceHeader.classIndex();
+        if(this.classIndex == Integer.MAX_VALUE) {
+          if(this.instanceHeader.instanceInformation.range!=null)
+            this.classIndex=this.instanceHeader.instanceInformation.range.getStart();
+          else
+            this.classIndex=0;
+        }
     }
 
     //Dense
@@ -286,14 +298,7 @@ public class InstanceImpl implements MultiLabelInstance {
      */
     @Override
     public int classIndex() {
-        int classIndex = instanceHeader.classIndex();
-       // return  ? classIndex : 0;
-        if(classIndex == Integer.MAX_VALUE)
-        	if(this.instanceHeader.instanceInformation.range!=null)
-        		classIndex=instanceHeader.instanceInformation.range.getStart();
-        	else
-        		classIndex=0;
-        return classIndex;
+        return this.classIndex;
     }
 
     /**


### PR DESCRIPTION
This change avoids calling InstanceImpl.instanceHeader.classIndex() at InstanceImpl.classIndex(). 
Instead, pre-calculate classIndex at initialization and cache the result. 